### PR TITLE
Small Business: Disqualify companies with >$1m in investment

### DIFF
--- a/Small-Business.md
+++ b/Small-Business.md
@@ -36,7 +36,7 @@ You may have "fair use" rights for the software under the law. These terms do no
 
 ## Small Business
 
-Use of the software for the benefit of your company is use for a permitted purpose if your company has fewer than 100 total individuals working as employees and independent contractors, and less than 1,000,000 USD (2019) total revenue in the prior tax year.  Adjust this revenue threshold for inflation according to the United States Bureau of Labor Statistics' consumer price index for all urban consumers, U.S. city average, for all items, not seasonally adjusted, with 1982–1984=100 reference base.
+Use of the software for the benefit of your company is use for a permitted purpose if your company has fewer than 100 total individuals working as employees and independent contractors, less than 1,000,000 USD (2019) total revenue in the prior tax year, and less than 1,000,000 USD (2019) total debt, equity, and other investment in the last five tax years, counting investment in predecessor companies that reorganized into, merged with, or spun out your company.  Adjust this revenue threshold for inflation according to the United States Bureau of Labor Statistics' consumer price index for all urban consumers, U.S. city average, for all items, not seasonally adjusted, with 1982–1984=100 reference base.
 
 ## No Other Rights
 


### PR DESCRIPTION
This PR adds language addressing a point of feedback that came up for the [Big Time License](https://bigtimelicense.com/): companies that don't have large headcount or revenue, but have received lots of external financing in the recent past.  Functionally, I've added another way to disqualify a company as "small": if it has had more than $1m in financing in the last five years.

Other good feedback pointed out that there isn't much comparability in the different metrics for "small", even just revenue and headcount.  It's certainly the case that carrying 100 headcount implies a minimum or either revenue or financing.  But most readers and potential license adopters seem to look for these definitions for a good, intuitive reflection of big versus small.  I think the important questions are whether the metrics we use as proxies for bigness will be easy to measure, or measured for some other purpose already.  I think that's just as true of outside investment as headcount or revenue.
