### PR TITLE
Notices: Drop obligation to reproduce `Required Notice:` lines

### DIFF
--- a/template.erb.md
+++ b/template.erb.md
@@ -110,7 +110,7 @@ The licensor gives you permission under any patent claims it can license, or bec
 <% if distribute %>
 ## Notices
 
-Make sure anyone who gets a copy of this software from you also gets a copy of this license or the URL for it above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with this software.
+Make sure anyone who gets a copy of this software from you also gets a copy of this license or the URL for it above.
 <% end %>
 
 ## Fair Use


### PR DESCRIPTION
@heathermeeker, what do you think about dropping PolyForm's requirement to reproduce notice lines with the magic string `Required Notice` from version 2s of the licenses?

There's obviously some precedent for this in Apache and a few other licenses. I'd say it's more common for corporate licensors to want this, and it was never _required_ to use the license. [Uses here on public GitHub](https://github.com/search?q=%22required+notice%3A%22&type=code) remain few.